### PR TITLE
Facades, MessageProcessor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,26 @@
 ## Logging exceptions
 The default settings enable logging of exceptions. It will add the HTTP request to the GELF message, but it will not add POST values. Check the graylog2.log-requests config to enable or disable this behavior.
 
+## Message Processors 
+Processors add extra functionality to the handler. You can register processors adding this to your AppServiceProvider:
+```php
+    Graylog2::registerProcessor(new \Swis\Graylog2\Processor\ExceptionProcessor());
+```
+In the default package, the following processors are available:
+### ExceptionProcessor
+Adds exception data to the message if there is any.
+### RequestProcessor
+Adds the current Laravel Request to the message. It adds the url, method and ip by default.
+
 ### Don't report exceptions
 In `app/Exceptions/Handler.php` you can define the $dontReport array with Exception classes that won't be reported to the logger. For example, you can blacklist the \Illuminate\Database\Eloquent\ModelNotFoundException. Check the [Laravel Documentation](https://laravel.com/docs/5.4/errors#the-exception-handler) about errors for more information.
-
-### Send default additional data
-Using the config, you can specify additional key => value data to be sent with the GELF message. For example, you can use this to add a client ID to a message.
 
 ## Logging arbitrary data
 You can instantiate the Graylog2 class to send additional GELF messages:
 
-```
-$graylog2 = app('graylog2');
-
-
+```php
 // Send default log message
-$graylog2->log('emergency', 'Dear Sir/Madam, Fire! Fire! Help me!. 123 Cavendon Road. Looking forward to hearing from you. Yours truly, Maurice Moss.', ['facility' => 'ICT']);
+Graylog2::log('emergency', 'Dear Sir/Madam, Fire! Fire! Help me!. 123 Cavendon Road. Looking forward to hearing from you. Yours truly, Maurice Moss.', ['facility' => 'ICT']);
 
 
 // Send custom GELF Message
@@ -36,7 +41,7 @@ $message->setShortMessage('Fire! Fire! Help me!');
 $message->setFullMessage('Dear Sir/Madam, Fire! Fire! Help me!. 123 Cavendon Road. Looking forward to hearing from you. Yours truly, Maurice Moss.');
 $message->setFacility('ICT');
 $message->setAdditional('employee', 'Maurice Moss');
-$graylog2->logMessage($message);
+Graylog2::logMessage($message);
 ```
 
 ## Troubleshooting

--- a/config/graylog2.php
+++ b/config/graylog2.php
@@ -7,6 +7,15 @@ return [
     // Log HTTP requests with exceptions
     'log_requests' => true,
 
+    // Log HTTP Request GET data
+    'log_request_get_data' => true,
+
+    // Log HTTP Request POST data
+    'log_request_post_data' => true,
+
+    // Filter out some sensitive post parameters
+    'disallowed_post_parameters' => ['password', 'username'],
+
     /*
      * Also add exception data in the full message.
      * This increases the size of the message by a lot. The

--- a/config/graylog2.php
+++ b/config/graylog2.php
@@ -5,7 +5,7 @@ return [
     'enabled' => true,
 
     // Log HTTP requests with exceptions
-    'log-requests' => true,
+    'log_requests' => true,
 
     /*
      * Also add exception data in the full message.
@@ -13,7 +13,7 @@ return [
      * exception information is also included in the 'exception'
      * field.
      */
-    'exception-in-full-message' => false,
+    'stack_trace_in_full_message' => false,
 
     'connection' => [
         'host' => '127.0.0.1',
@@ -22,19 +22,5 @@ return [
 
         // Set to UdpTransport::CHUNK_SIZE_LAN as a default
         'chunk_size' => '8154',
-    ],
-
-    /*
-     * Add additional context to the GELF message
-     */
-    'context' => [
-        'host' => 'localhost',
-        'version' => 'v1',
-        'facility' => 'default-facility',
-    ],
-
-    // Allows you to set additional fields in the GELF message, use key => value
-    'additional-fields' => [
-
     ]
 ];

--- a/config/graylog2.php
+++ b/config/graylog2.php
@@ -8,10 +8,10 @@ return [
     'log_requests' => true,
 
     // Log HTTP Request GET data
-    'log_request_get_data' => true,
+    'log_request_get_data' => false,
 
     // Log HTTP Request POST data
-    'log_request_post_data' => true,
+    'log_request_post_data' => false,
 
     // Filter out some sensitive post parameters
     'disallowed_post_parameters' => ['password', 'username'],

--- a/src/Facades/Graylog2.php
+++ b/src/Facades/Graylog2.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Swis\Graylog2\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Graylog2 extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'graylog2';
+    }
+}

--- a/src/Graylog2.php
+++ b/src/Graylog2.php
@@ -36,7 +36,12 @@ class Graylog2 extends AbstractLogger
     public function log($level, $message, array $context = [])
     {
         $gelfMessage = $this->logger->prepareLog($level, $message, $context);
-        $gelfMessage = $this->invokeProcessors($gelfMessage);
+        $exception = null;
+        if (array_key_exists('exception', $context)) {
+            $exception = $context['exception'];
+        }
+
+        $gelfMessage = $this->invokeProcessors($gelfMessage, $exception, $context);
         $this->logger->publishMessage($gelfMessage);
     }
 
@@ -101,10 +106,10 @@ class Graylog2 extends AbstractLogger
      *
      * @return Message
      */
-    private function invokeProcessors(Message $message, $exception = null)
+    private function invokeProcessors(Message $message, $exception = null, $context = [])
     {
         foreach ($this->processors as $processor) {
-            $message = $processor->process($message, $exception);
+            $message = $processor->process($message, $exception, $context);
         }
 
         return $message;

--- a/src/Graylog2.php
+++ b/src/Graylog2.php
@@ -103,6 +103,7 @@ class Graylog2 extends AbstractLogger
     /**
      * @param Message $message
      * @param null    $exception
+     * @param mixed   $context
      *
      * @return Message
      */

--- a/src/Graylog2Handler.php
+++ b/src/Graylog2Handler.php
@@ -17,29 +17,22 @@ class Graylog2Handler extends AbstractHandler
             return false;
         }
 
+        // Handle a log from Laravel
+        /** @var Graylog2 $graylog2 */
+        $graylog2 = app('graylog2');
+
         try {
-            /** @var Graylog2 $graylog2 */
-            $graylog2 = app('graylog2');
-
-            $context = array_merge(
-                $record['context'],
-                [
-                    'extra'   => $record['extra'],
-                    'channel' => $record['channel'],
-                ]
-            );
-
-            if (config('graylog2.log-requests')) {
-                $context['request'] = app('Illuminate\Http\Request');
-            }
-
             $graylog2->log(
                 strtolower($record['level_name']),
                 $record['message'],
-                $context
+                $record['context']
             );
+
+            return true;
         } catch (\Exception $e) {
-            Log::error('Cannot log the error to Graylog2.');
+            Log::info('Could not log to Graylog.');
+
+            return false;
         }
     }
 }

--- a/src/Graylog2ServiceProvider.php
+++ b/src/Graylog2ServiceProvider.php
@@ -23,12 +23,20 @@ class Graylog2ServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('graylog2', function ($app) {
-            return new Graylog2();
-        });
+        $this->app->singleton('graylog2', Graylog2::class);
 
         // Register handler
         $monoLog = Log::getMonolog();
         $monoLog->pushHandler(new Graylog2Handler());
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return ['graylog2'];
     }
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -2,7 +2,6 @@
 
 namespace Swis\Graylog2;
 
-use Exception;
 use Gelf\Logger as GelfLogger;
 use Gelf\Message;
 
@@ -20,16 +19,7 @@ class Logger extends GelfLogger
      */
     public function prepareLog($level, $rawMessage, array $context = [])
     {
-        $message = $this->initMessage($level, $rawMessage, $context);
-
-        // add exception data if present
-        if (isset($context['exception'])
-            && $context['exception'] instanceof \Exception
-        ) {
-            $this->initExceptionData($message, $context['exception']);
-        }
-
-        return $message;
+        return $this->initMessage($level, $rawMessage, $context);
     }
 
     /**
@@ -40,35 +30,5 @@ class Logger extends GelfLogger
     public function publishMessage(Message $message)
     {
         $this->publisher->publish($message);
-    }
-
-    /**
-     * Initializes Exceptiondata with given message.
-     *
-     * @param Message   $message
-     * @param Exception $exception
-     */
-    protected function initExceptionData(Message $message, Exception $exception)
-    {
-        $message->setLine($exception->getLine());
-        $message->setFile($exception->getFile());
-
-        if (!config('graylog2.exception-in-full-message')) {
-            return;
-        }
-
-        $longText = '';
-        do {
-            $longText .= sprintf(
-                    "%s: %s (%d)\n\n%s\n",
-                    get_class($exception),
-                    $exception->getMessage(),
-                    $exception->getCode(),
-                    $exception->getTraceAsString()
-                );
-
-            $exception = $exception->getPrevious();
-        } while ($exception && $longText .= "\n--\n\n");
-        $message->setFullMessage($longText);
     }
 }

--- a/src/Processor/ExceptionProcessor.php
+++ b/src/Processor/ExceptionProcessor.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Swis\Graylog2\Processor;
+
+class ExceptionProcessor implements ProcessorInterface
+{
+    /**
+     * Process the message and exception when present.
+     *
+     * @param \Gelf\Message   $message
+     * @param \Exception|null $exception
+     *
+     * @return mixed
+     */
+    public function process($message, $exception)
+    {
+        // Don't process the log when there is no Exception
+        if ($exception === null) {
+            return $message;
+        }
+
+        $message->setLine($exception->getLine());
+        $message->setFile($exception->getFile());
+
+        // Check if we want the full stack trace in the message
+        if (!config('graylog2.stack_trace_in_full_message', false)) {
+            return $message;
+        }
+
+        $longText = '';
+        do {
+            $longText .= sprintf(
+                "%s: %s (%d)\n\n%s\n",
+                get_class($exception),
+                $exception->getMessage(),
+                $exception->getCode(),
+                $exception->getTraceAsString()
+            );
+
+            $exception = $exception->getPrevious();
+        } while ($exception && $longText .= "\n--\n\n");
+        $message->setFullMessage($longText);
+
+        return $message;
+    }
+}

--- a/src/Processor/ExceptionProcessor.php
+++ b/src/Processor/ExceptionProcessor.php
@@ -9,6 +9,7 @@ class ExceptionProcessor implements ProcessorInterface
      *
      * @param \Gelf\Message   $message
      * @param \Exception|null $exception
+     * @param mixed           $context
      *
      * @return mixed
      */

--- a/src/Processor/ExceptionProcessor.php
+++ b/src/Processor/ExceptionProcessor.php
@@ -12,7 +12,7 @@ class ExceptionProcessor implements ProcessorInterface
      *
      * @return mixed
      */
-    public function process($message, $exception)
+    public function process($message, $exception, $context)
     {
         // Don't process the log when there is no Exception
         if ($exception === null) {

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -11,6 +11,7 @@ interface ProcessorInterface
      *
      * @param Message         $message
      * @param \Exception|null $exception
+     * @param mixed           $context
      *
      * @return Message
      */

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -14,5 +14,5 @@ interface ProcessorInterface
      *
      * @return Message
      */
-    public function process($message, $exception);
+    public function process($message, $exception, $context);
 }

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Swis\Graylog2\Processor;
+
+use Gelf\Message;
+
+interface ProcessorInterface
+{
+    /**
+     * Process the message and exception when present.
+     *
+     * @param Message         $message
+     * @param \Exception|null $exception
+     *
+     * @return Message
+     */
+    public function process($message, $exception);
+}

--- a/src/Processor/RequestProcessor.php
+++ b/src/Processor/RequestProcessor.php
@@ -30,8 +30,6 @@ class RequestProcessor implements ProcessorInterface
 
         // Add GET data if configured
         if (config('graylog2.log_request_get_data', false)) {
-
-            //dd($request);
             $message->setAdditional('request_get_data', json_encode($request->query()));
         }
 
@@ -39,7 +37,7 @@ class RequestProcessor implements ProcessorInterface
         if (config('graylog2.log_request_post_data', false)) {
             $disallowedParameters = config('graylog2.disallowed_post_parameters', []);
             $filteredParameters = array_filter(
-                $_POST,
+                $request->request->all(),
                 function ($key) use ($disallowedParameters) {
                     return !in_array($key, $disallowedParameters);
                 },

--- a/src/Processor/RequestProcessor.php
+++ b/src/Processor/RequestProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Swis\Graylog2\Processor;
+
+use Illuminate\Http\Request;
+
+class RequestProcessor implements ProcessorInterface
+{
+    /**
+     * Process the message and exception when present.
+     *
+     * @param \Gelf\Message   $message
+     * @param \Exception|null $exception
+     *
+     * @return mixed
+     */
+    public function process($message, $exception)
+    {
+        // Don't process when the setting is off
+        if (!config('graylog2.log_requests', false)) {
+            return $message;
+        }
+
+        // Check for a request in the context or a request from Laravel
+
+        /** @var Request $request */
+        $request = null;
+        if (!empty($context['request']) && $context['request'] instanceof Request) {
+            $request = $context['request'];
+        } else {
+            $request = app('Illuminate\Http\Request');
+        }
+
+        if (!$request) {
+            return $message;
+        }
+
+        return $message
+                ->setAdditional('request_url', $request->url())
+                ->setAdditional('request_method', $request->method())
+                ->setAdditional('request_ip', $request->ip());
+    }
+}

--- a/src/Processor/RequestProcessor.php
+++ b/src/Processor/RequestProcessor.php
@@ -11,6 +11,7 @@ class RequestProcessor implements ProcessorInterface
      *
      * @param \Gelf\Message   $message
      * @param \Exception|null $exception
+     * @param mixed           $context
      *
      * @return mixed
      */

--- a/tests/Graylog2Test.php
+++ b/tests/Graylog2Test.php
@@ -100,7 +100,8 @@ class Graylog2Test extends AbstractTest
         Graylog2::logGelfMessage($message);
     }
 
-    public function testRequestProcessorParameters() {
+    public function testRequestProcessorParameters()
+    {
         Graylog2::registerProcessor(new \Swis\Graylog2\Processor\RequestProcessor());
 
         $self = $this;

--- a/tests/Graylog2Test.php
+++ b/tests/Graylog2Test.php
@@ -55,11 +55,10 @@ class Graylog2Test extends AbstractTest
         $graylog2->registerProcessor(new \Swis\Graylog2\Processor\ExceptionProcessor());
 
         $e = new \Exception('test Exception', 300);
-        $l = __LINE__;
 
         $self = $this;
-        $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self, $l) {
-            $self->assertEquals($l, $message->getLine());
+        $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self, $e) {
+            $self->assertEquals($e->getLine(), $message->getLine());
         });
 
         $graylog2->addTransportToPublisher($testTransport);

--- a/tests/Graylog2Test.php
+++ b/tests/Graylog2Test.php
@@ -48,43 +48,22 @@ class Graylog2Test extends AbstractTest
     /**
      * Tests the generation of a GELF message.
      */
-    public function testAdditionalFields()
-    {
-        // Set additional fields
-        $this->app['config']->set('graylog2.additional-fields', [
-            'a' => 'b',
-        ]);
-
-        $graylog2 = new Graylog2();
-
-        $self = $this;
-        $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self) {
-            $self->assertEquals('b', $message->getAdditional('a'));
-        });
-
-        $graylog2->addTransportToPublisher($testTransport);
-        $graylog2->log('error', 'test', []);
-    }
-
-    /**
-     * Tests the generation of a GELF message.
-     */
     public function testException()
     {
         // Set additional fields
         $graylog2 = new Graylog2();
+        $graylog2->registerProcessor(new \Swis\Graylog2\Processor\ExceptionProcessor());
 
         $e = new \Exception('test Exception', 300);
+        $l = __LINE__;
 
         $self = $this;
-        $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self) {
-            $self->assertEquals('77', $message->getLine());
+        $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self, $l) {
+            $self->assertEquals($l, $message->getLine());
         });
 
         $graylog2->addTransportToPublisher($testTransport);
-        $graylog2->log('error', 'test', [
-            'exception' => $e,
-        ]);
+        $graylog2->logException($e);
     }
 
     /**
@@ -94,6 +73,7 @@ class Graylog2Test extends AbstractTest
     {
         // Set additional fields
         $graylog2 = new Graylog2();
+        $graylog2->registerProcessor(new \Swis\Graylog2\Processor\RequestProcessor());
 
         $self = $this;
         $testTransport = new TestGraylog2Transport(function (\Gelf\MessageInterface $message) use ($self) {
@@ -126,6 +106,6 @@ class Graylog2Test extends AbstractTest
         $message = new \Gelf\Message();
         $message->setShortMessage('Test Message');
 
-        $graylog2->logMessage($message);
+        $graylog2->logGelfMessage($message);
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -11,8 +11,7 @@ class HandlerTest extends AbstractTest
     public function testEnabling()
     {
         $handler = new Graylog2Handler();
-
-        $this->assertNull($handler->handle([]));
+        $this->assertFalse($handler->handle([]));
 
         $this->app['config']->set('graylog2.enabled', false);
         $this->assertFalse($handler->handle([]));

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -28,20 +28,4 @@ class LoggerTest extends AbstractTest
             $message
         );
     }
-
-    /**
-     * Test the preparation of an exception.
-     */
-    public function testExceptionPreparation()
-    {
-        $logger = new \Swis\Graylog2\Logger();
-
-        $exception = new \Exception('Test', 300);
-
-        $message = $logger->prepareLog('emergency', 'Test Message', ['exception' => $exception])->toArray();
-
-        $this->assertArrayHasKey('file', $message);
-        $this->assertEquals('Test Message', $message['short_message']);
-        $this->assertEquals('39', $message['line']);
-    }
 }


### PR DESCRIPTION
# Changes to message processing

- Added Facade for easier access
- Adding additional data is now handled by MessageProcessors. By default, we ship an ExceptionProcessor and a RequestProcessor. Additional processors can be made by implementing `ProcessorInterface` and adding them to your `AppProvider`.
- Request logging can now add GET and/or POST parameters. POST parameters can be blacklisted (think passwords/usernames)