### PR TITLE
Added validation of Graylog transport configuration values

### DIFF
--- a/config/graylog2.php
+++ b/config/graylog2.php
@@ -27,6 +27,12 @@ return [
     'connection' => [
         'host' => '127.0.0.1',
         'port' => '12201',
+
+        /*
+         * Choose between UDP and TCP transport. 
+         * UDP transports won't throw exceptions on transport errors,
+         * but message reception by the Graylog server is not guaranteed.
+         */
         'type' => 'UDP',
 
         // Set to UdpTransport::CHUNK_SIZE_LAN as a default

--- a/src/Graylog2.php
+++ b/src/Graylog2.php
@@ -122,17 +122,19 @@ class Graylog2 extends AbstractLogger
     private function setupGraylogTransport()
     {
         // Setup the transport
-        if ('UDP' === config('graylog2.connection.type')) {
+        if ('UDP' === strtoupper(config('graylog2.connection.type'))) {
             $transport = new UdpTransport(
                 config('graylog2.connection.host'),
                 config('graylog2.connection.port'),
                 config('graylog2.connection.chunk_size')
             );
-        } else {
+        } elseif ('TCP' === strtoupper(config('graylog2.connection.type'))) {
             $transport = new TcpTransport(
                 config('graylog2.connection.host'),
                 config('graylog2.connection.port')
             );
+        } else {
+            throw new \DomainException('Invalid Graylog Transport, should be set to TCP or UDP.');
         }
 
         // Setup publisher and logger

--- a/tests/Graylog2Test.php
+++ b/tests/Graylog2Test.php
@@ -127,4 +127,14 @@ class Graylog2Test extends AbstractTest
 
         Graylog2::log('error', 'test', []);
     }
+
+    /**
+     * Tests checking the Graylog transport configuration value.
+     */
+    public function testInvalidTransportConfiguration()
+    {
+        Config::set('graylog2.connection.type', 'INVALID');
+        $this->expectException(\DomainException::class);
+        Graylog2::log('emergency', 'test', []);
+    }
 }


### PR DESCRIPTION
- Added a comment to the config to clarify the options
- The following values are valid for the transport type:
    - `udp`
    - `UDP`
    - `tcp`
    - `TCP`
- Added test
- Fixes #2