### PR TITLE
Fix minimum log level.

### DIFF
--- a/src/Graylog2ServiceProvider.php
+++ b/src/Graylog2ServiceProvider.php
@@ -27,7 +27,7 @@ class Graylog2ServiceProvider extends ServiceProvider
 
         // Register handler
         $monoLog = Log::getMonolog();
-        $monoLog->pushHandler(new Graylog2Handler(), config('graylog2.log_level', 'debug'));
+        $monoLog->pushHandler(new Graylog2Handler(config('graylog2.log_level', 'debug')));
     }
 
     /**


### PR DESCRIPTION
I have made a mistake in my recent PR as the log level is not an argument of the pushHandler method of Monolog but instead is an argument for the construct method of the AbstractHandler class, which is extended by Graylog2Handler.
This PR fixes the problem, sorry. 