### PR TITLE
Improve ServiceProvider

### DIFF
--- a/src/Graylog2ServiceProvider.php
+++ b/src/Graylog2ServiceProvider.php
@@ -7,6 +7,9 @@ use Illuminate\Support\ServiceProvider;
 
 class Graylog2ServiceProvider extends ServiceProvider
 {
+    
+    protected $defer = true;
+    
     /**
      * Bootstrap the application events.
      */
@@ -16,6 +19,10 @@ class Graylog2ServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/graylog2.php' => $this->app->configPath().'/graylog2.php',
         ]);
+        
+        // Register handler
+        $monoLog = Log::getMonolog();
+        $monoLog->pushHandler(new Graylog2Handler(config('graylog2.log_level', 'debug')));
     }
 
     /**
@@ -24,10 +31,6 @@ class Graylog2ServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('graylog2', Graylog2::class);
-
-        // Register handler
-        $monoLog = Log::getMonolog();
-        $monoLog->pushHandler(new Graylog2Handler(config('graylog2.log_level', 'debug')));
     }
 
     /**


### PR DESCRIPTION
- moved push Monolog handler in `boot` method as in Laravel documentation (https://laravel.com/docs/5.6/providers#the-register-method)
- added $defer = true in order to have a deferred provider (otherwise 'provides` method is useless)